### PR TITLE
Producer urls on index page are now clickable

### DIFF
--- a/src/views/chain/Producers.vue
+++ b/src/views/chain/Producers.vue
@@ -42,7 +42,9 @@
 						<td class="desktop-only">{{producer.owner}}</td>
 							<td class="desktop-only">{{producer.country_code}}</td>
 						<td>{{(producer.total_votes / chainState.total_producer_vote_weight * 100).toFixed(5)}}%</td>
-						<td class="desktop-only">{{producer.url}}</td>
+						<td class="desktop-only">
+              <a :href="producer.url" target="_blank">{{producer.url}}</a>
+            </td>
 						<td>
 							<button @click="toggleVoteFor(producer.owner)" v-if="account" :class="{'active':hasVotedFor(producer.owner)}">{{ $t('lang.vote') }}</button>
 						</td>


### PR DESCRIPTION
* for convenience, if the url is displayed anyways it might as well be clickable
* home page opens in a new tab (same behaviour as on the producer show page)

**Question:** Do URLs need to be sanitized first? It seemed like they might already be sanitized somewhere, but not quite sure.

### Before:

![image](https://user-images.githubusercontent.com/2923/41207159-acb758ea-6cde-11e8-8b34-dc43ee06f05e.png)

### After:

![image](https://user-images.githubusercontent.com/2923/41207152-94a1e004-6cde-11e8-83da-831474121d95.png)
