### PR TITLE
Changed ports and added https for liquideos endpoint

### DIFF
--- a/src/views/Chain.vue
+++ b/src/views/Chain.vue
@@ -76,7 +76,8 @@
             if(!chainData) return this.$router.push({path:'/'});
 
             chainData.nodes = [
-                "http://node2.liquideos.com:8888",
+                "http://node2.liquideos.com:80",
+                "https://node2.liquideos.com:443",
                 "https://api.eosmetal.io:18890",
                 "http://185.109.149.236:8888"
             ];


### PR DESCRIPTION
some people behind corporate firewalls are reporting issues with ports other than the standard http/https ports. 

we added support for these ports in our endpoint (the old ones are kept active as well) and we also added ssl support.