### PR TITLE
changing ceil to floor.

### DIFF
--- a/src/views/chain/Producers.vue
+++ b/src/views/chain/Producers.vue
@@ -155,7 +155,7 @@ export default class Producers extends Vue {
 
     let timestamp_epoch:number = 946684800000;
     let dates_:number = (Date.now() / 1000) - (timestamp_epoch / 1000);
-    let weight_:number = Math.ceil(dates_ / (86400 * 7)) / 52;  //86400 = seconds per day 24*3600
+    let weight_:number = Math.floor(dates_ / (86400 * 7)) / 52;  //86400 = seconds per day 24*3600
     return Math.pow(2, weight_);
   }
 


### PR DESCRIPTION
Fixes https://github.com/EOSPortal/eosportal-front/issues/59

Currently when Math.ceil is used it rounds up the value to the next higher integer value. But based on the code present it should drop the decimal places and keep the integer value as it is. 